### PR TITLE
Переписать приложение для хранения книг на ORM

### DIFF
--- a/spring-library/pom.xml
+++ b/spring-library/pom.xml
@@ -19,6 +19,7 @@
         <spirng.shell.version>2.0.1.RELEASE</spirng.shell.version>
         <postgresql.version>42.2.9</postgresql.version>
         <junit-jupiter.version>5.5.2</junit-jupiter.version>
+        <h2.version>1.4.200</h2.version>
     </properties>
 
     <dependencies>
@@ -40,12 +41,13 @@
         <!--DB-->
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-jdbc</artifactId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.postgresql</groupId>
-            <artifactId>postgresql</artifactId>
-            <version>${postgresql.version}</version>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+            <version>${h2.version}</version>
         </dependency>
         <!--TEST-->
         <dependency>

--- a/spring-library/src/main/java/ru/otus/homework/springlibrary/SpringLibraryApplication.java
+++ b/spring-library/src/main/java/ru/otus/homework/springlibrary/SpringLibraryApplication.java
@@ -9,5 +9,4 @@ public class SpringLibraryApplication {
     public static void main(String[] args) {
         SpringApplication.run(SpringLibraryApplication.class, args);
     }
-
 }

--- a/spring-library/src/main/java/ru/otus/homework/springlibrary/domain/Book.java
+++ b/spring-library/src/main/java/ru/otus/homework/springlibrary/domain/Book.java
@@ -1,35 +1,60 @@
 package ru.otus.homework.springlibrary.domain;
 
 import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import lombok.ToString;
 
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
+import javax.persistence.ManyToMany;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
 import java.util.List;
 
 @AllArgsConstructor
 @Getter
 @Setter
-@ToString
 @NoArgsConstructor
-@EqualsAndHashCode
+@Entity
+@Table(name = "books")
 public class Book {
 
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(name = "name")
     private String name;
+
+    @Column(name = "releaseYear")
     private Integer releaseYear;
+
+    @ManyToMany(targetEntity = Author.class, fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinTable(name = "authors_books",
+            joinColumns = @JoinColumn(name = "book_id"),
+            inverseJoinColumns = @JoinColumn(name = "author_id"))
     private List<Author> authors;
+
+    @ManyToMany(targetEntity = Genre.class, fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinTable(name = "books_genres",
+            joinColumns = @JoinColumn(name = "book_id"),
+            inverseJoinColumns = @JoinColumn(name = "genre_id"))
     private List<Genre> genres;
+
+    @OneToMany(targetEntity = Comment.class, fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "book_id")
+    private List<Comment> comments;
 
     public Book(long id, String name, int releaseYear) {
         this.id = id;
-        this.name = name;
-        this.releaseYear = releaseYear;
-    }
-
-    public Book(String name, int releaseYear) {
         this.name = name;
         this.releaseYear = releaseYear;
     }
@@ -39,5 +64,13 @@ public class Book {
         this.releaseYear = releaseYear;
         this.authors = authors;
         this.genres = genres;
+    }
+
+    @Override
+    public String toString() {
+        return "id = " + getId() +
+                "; bookName = " + getName() +
+                "; bookAuthors = " + getAuthors() +
+                "; genres of Book " + getGenres();
     }
 }

--- a/spring-library/src/main/java/ru/otus/homework/springlibrary/domain/Comment.java
+++ b/spring-library/src/main/java/ru/otus/homework/springlibrary/domain/Comment.java
@@ -11,26 +11,21 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
 
-@AllArgsConstructor
-@NoArgsConstructor
-@Data
 @Entity
-@Table(name = "authors")
-public class Author {
+@NoArgsConstructor
+@AllArgsConstructor
+@Data
+@Table(name = "comments")
+public class Comment {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    @Column(name = "name")
-    private String name;
-    @Column(name = "country")
-    private String country;
 
-    public Author(String name) {
-        this.name = name;
-    }
+    @Column(name = "comment")
+    private String comment;
 
-    public Author(String name, String country) {
-        this.name = name;
-        this.country = country;
+    public Comment(String comment) {
+        this.comment = comment;
     }
 }

--- a/spring-library/src/main/java/ru/otus/homework/springlibrary/domain/Genre.java
+++ b/spring-library/src/main/java/ru/otus/homework/springlibrary/domain/Genre.java
@@ -1,21 +1,27 @@
 package ru.otus.homework.springlibrary.domain;
 
 import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
+import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
 
-@Getter
-@Setter
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
 @NoArgsConstructor
 @AllArgsConstructor
-@ToString
-@EqualsAndHashCode
+@Data
+@Entity
+@Table(name = "genres")
 public class Genre {
 
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+    @Column(name = "name")
     private String name;
 
     public Genre(String name) {

--- a/spring-library/src/main/java/ru/otus/homework/springlibrary/repositories/AuthorRepository.java
+++ b/spring-library/src/main/java/ru/otus/homework/springlibrary/repositories/AuthorRepository.java
@@ -1,0 +1,23 @@
+package ru.otus.homework.springlibrary.repositories;
+
+import ru.otus.homework.springlibrary.domain.Author;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public interface AuthorRepository {
+
+    Long count();
+
+    List<Author> getAllAuthors();
+
+    void deleteAuthorById(Long authorId);
+
+    Optional<Author> getAuthorById(Long authorId);
+
+    Author save(Author author);
+
+    void updateAuthorById(Long authorId, Map<String, String> updatedFields);
+
+}

--- a/spring-library/src/main/java/ru/otus/homework/springlibrary/repositories/BookRepository.java
+++ b/spring-library/src/main/java/ru/otus/homework/springlibrary/repositories/BookRepository.java
@@ -1,0 +1,24 @@
+package ru.otus.homework.springlibrary.repositories;
+
+import ru.otus.homework.springlibrary.domain.Book;
+import ru.otus.homework.springlibrary.domain.Comment;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface BookRepository {
+
+    Long count();
+
+    List<Book> getAllBooks();
+
+    void deleteBookById(Long bookId);
+
+    Optional<Book> getBookById(Long bookId);
+
+    Book save(Book book);
+
+    void updateBookById(Long bookId, String authorName, Integer releaseYear, String bookName, String genreName);
+
+    void addCommentToBook(Long bookId, Comment comment);
+}

--- a/spring-library/src/main/java/ru/otus/homework/springlibrary/repositories/GenreRepository.java
+++ b/spring-library/src/main/java/ru/otus/homework/springlibrary/repositories/GenreRepository.java
@@ -1,0 +1,22 @@
+package ru.otus.homework.springlibrary.repositories;
+
+import ru.otus.homework.springlibrary.domain.Genre;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public interface GenreRepository {
+
+    Long count();
+
+    List<Genre> getAllGenres();
+
+    void deleteGenreById(Long genreId);
+
+    Optional<Genre> getGenreById(Long genreId);
+
+    Genre save(Genre genre);
+
+    void updateGenreById(Long id, Map<String, String> updatedFields);
+}

--- a/spring-library/src/main/java/ru/otus/homework/springlibrary/repositories/impl/AuthorRepositoryImpl.java
+++ b/spring-library/src/main/java/ru/otus/homework/springlibrary/repositories/impl/AuthorRepositoryImpl.java
@@ -1,0 +1,72 @@
+package ru.otus.homework.springlibrary.repositories.impl;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+import ru.otus.homework.springlibrary.domain.Author;
+import ru.otus.homework.springlibrary.repositories.AuthorRepository;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.persistence.Query;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Slf4j
+@Repository
+public class AuthorRepositoryImpl implements AuthorRepository {
+
+    @PersistenceContext
+    private final EntityManager entityManager;
+
+    @Override
+    public Long count() {
+        return entityManager.createQuery("SELECT COUNT(a.id) from Author a", Long.class).getResultList().get(0);
+    }
+
+    @Override
+    public List<Author> getAllAuthors() {
+        return entityManager.createQuery("SELECT a FROM Author a", Author.class).getResultList();
+    }
+
+    @Transactional
+    @Override
+    public void deleteAuthorById(Long authorId) {
+        Query query = entityManager.createQuery("DELETE FROM Author a WHERE a.id = :id");
+        query.setParameter("id", authorId);
+        query.executeUpdate();
+    }
+
+    @Transactional
+    @Override
+    public Optional<Author> getAuthorById(Long authorId) {
+        return Optional.ofNullable(entityManager.find(Author.class, authorId));
+    }
+
+    @Transactional
+    @Override
+    public Author save(Author author) {
+        if (author.getId() == null) {
+            entityManager.persist(author);
+        } else {
+            return entityManager.merge(author);
+        }
+        return author;
+    }
+
+    @Transactional
+    @Override
+    public void updateAuthorById(Long authorId, Map<String, String> updatedFields) {
+        Author preparedAuthor = getAuthorById(authorId).orElseThrow();
+        if (updatedFields.containsKey("name")) {
+            preparedAuthor.setName(updatedFields.get("name"));
+        }
+        if (updatedFields.containsKey("country")) {
+            preparedAuthor.setCountry(updatedFields.get("country"));
+        }
+        entityManager.merge(preparedAuthor);
+    }
+}

--- a/spring-library/src/main/java/ru/otus/homework/springlibrary/repositories/impl/BookRepositoryImpl.java
+++ b/spring-library/src/main/java/ru/otus/homework/springlibrary/repositories/impl/BookRepositoryImpl.java
@@ -1,0 +1,146 @@
+package ru.otus.homework.springlibrary.repositories.impl;
+
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.Hibernate;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+import ru.otus.homework.springlibrary.domain.Author;
+import ru.otus.homework.springlibrary.domain.Book;
+import ru.otus.homework.springlibrary.domain.Comment;
+import ru.otus.homework.springlibrary.domain.Genre;
+import ru.otus.homework.springlibrary.repositories.BookRepository;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.persistence.Query;
+import javax.persistence.TypedQuery;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@Slf4j
+public class BookRepositoryImpl implements BookRepository {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Override
+    public Long count() {
+        return (long) entityManager.createQuery("SELECT COUNT(id) FROM Book").getResultList().get(0);
+    }
+
+    @Transactional
+    @Override
+    public Book save(Book book) {
+        if (book.getId() == null) {
+            entityManager.persist(book);
+            return book;
+        } else {
+            return entityManager.merge(book);
+        }
+    }
+
+    @Transactional
+    @Override
+    public void updateBookById(Long bookId, String authorName, Integer releaseYear, String bookName, String genreName) {
+        Book book = entityManager.find(Book.class, bookId);
+        if (authorName != null) {
+            addAuthorToBook(book, authorName);
+        }
+        if (genreName != null) {
+            addGenreToBook(book, genreName);
+        }
+
+        if (releaseYear != 0) {
+            book.setReleaseYear(releaseYear);
+            entityManager.merge(book);
+        }
+        if (bookName != null) {
+            book.setName(bookName);
+            entityManager.merge(book);
+        }
+    }
+
+    @Transactional
+    @Override
+    public List<Book> getAllBooks() {
+        TypedQuery<Book> select_b_from_book_b = entityManager.createQuery("SELECT b FROM Book b", Book.class);
+        List<Book> resultList = select_b_from_book_b.getResultList();
+        resultList.forEach(book -> {
+            Hibernate.initialize(book.getAuthors());
+            Hibernate.initialize(book.getGenres());
+        });
+        return resultList;
+    }
+
+    @Transactional
+    @Override
+    public void deleteBookById(Long bookId) {
+        Query deleteQuery = entityManager.createQuery("DELETE FROM Book b WHERE b.id = :id");
+        deleteQuery.setParameter("id", bookId);
+        deleteQuery.executeUpdate();
+    }
+
+    @Transactional
+    @Override
+    public Optional<Book> getBookById(Long bookId) {
+        TypedQuery<Book> query = entityManager.createQuery("SELECT b FROM Book b WHERE b.id = :bookId", Book.class);
+        query.setParameter("bookId", bookId);
+        Book bookById = query.getSingleResult();
+        if (bookById != null) {
+            if (bookById.getAuthors() != null) {
+                Hibernate.initialize(bookById.getAuthors());
+            }
+            if (bookById.getGenres() != null) {
+                Hibernate.initialize(bookById.getGenres());
+            }
+            if (bookById.getComments() != null) {
+                Hibernate.initialize(bookById.getComments());
+            }
+        }
+        return Optional.ofNullable(bookById);
+    }
+
+    @Transactional
+    @Override
+    public void addCommentToBook(Long bookId, Comment comment) {
+        Book book = entityManager.find(Book.class, bookId);
+        if (book.getComments() == null) {
+            List<Comment> bookComments = new ArrayList<>();
+            bookComments.add(comment);
+            book.setComments(bookComments);
+        } else {
+            book.getComments().add(comment);
+        }
+        entityManager.merge(book);
+    }
+
+    private void addAuthorToBook(Book book, String authorName) {
+        List<Author> authors = book.getAuthors();
+        if (authors == null) {
+            List<Author> createdAuthor = new ArrayList<>();
+            createdAuthor.add(new Author(authorName));
+            book.setAuthors(createdAuthor);
+        } else {
+            if (authors.stream().noneMatch(author -> author.getName().equals(authorName))) {
+                book.getAuthors().add(new Author(authorName));
+            }
+        }
+        entityManager.merge(book);
+    }
+
+    private void addGenreToBook(Book book, String genreName) {
+        List<Genre> genresOfBook = book.getGenres();
+        if (genresOfBook == null) {
+            List<Genre> genres = new ArrayList<>();
+            genres.add(new Genre(genreName));
+            book.setGenres(genres);
+        } else {
+            if (genresOfBook.stream().noneMatch(genre -> genre.getName().equals(genreName))) {
+                book.getGenres().add(new Genre(genreName));
+            }
+        }
+        entityManager.merge(book);
+    }
+}

--- a/spring-library/src/main/java/ru/otus/homework/springlibrary/repositories/impl/GenreRepositoryImpl.java
+++ b/spring-library/src/main/java/ru/otus/homework/springlibrary/repositories/impl/GenreRepositoryImpl.java
@@ -1,0 +1,70 @@
+package ru.otus.homework.springlibrary.repositories.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import ru.otus.homework.springlibrary.domain.Genre;
+import ru.otus.homework.springlibrary.repositories.GenreRepository;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import javax.persistence.Query;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Service
+@Repository
+public class GenreRepositoryImpl implements GenreRepository {
+
+    @PersistenceContext
+    private final EntityManager entityManager;
+
+    @Override
+    public Long count() {
+        return entityManager.createQuery("SELECT COUNT(g.id) FROM Genre g", Long.class).getResultList().get(0);
+    }
+
+    @Transactional
+    @Override
+    public List<Genre> getAllGenres() {
+        return entityManager.createQuery("SELECT g FROM Genre g", Genre.class).getResultList();
+    }
+
+    @Transactional
+    @Override
+    public void deleteGenreById(Long genreId) {
+        Query query = entityManager.createQuery("DELETE FROM Genre g WHERE g.id = :id");
+        query.setParameter("id", genreId);
+        query.executeUpdate();
+    }
+
+    @Transactional
+    @Override
+    public Optional<Genre> getGenreById(Long genreId) {
+        return Optional.ofNullable(entityManager.find(Genre.class, genreId));
+    }
+
+    @Transactional
+    @Override
+    public Genre save(Genre genre) {
+        if (genre.getId() == null) {
+            entityManager.persist(genre);
+        } else {
+            return entityManager.merge(genre);
+        }
+        return genre;
+    }
+
+    @Transactional
+    @Override
+    public void updateGenreById(Long id, Map<String, String> updatedFields) {
+        if (updatedFields.containsKey("name")) {
+            Genre genre = getGenreById(id).orElseThrow();
+            genre.setName(updatedFields.get("name"));
+            entityManager.merge(genre);
+        }
+    }
+}

--- a/spring-library/src/main/java/ru/otus/homework/springlibrary/service/BooksCrudService.java
+++ b/spring-library/src/main/java/ru/otus/homework/springlibrary/service/BooksCrudService.java
@@ -1,6 +1,7 @@
 package ru.otus.homework.springlibrary.service;
 
 import ru.otus.homework.springlibrary.domain.Book;
+import ru.otus.homework.springlibrary.domain.Comment;
 
 import java.util.List;
 
@@ -17,5 +18,9 @@ public interface BooksCrudService {
     void updateBook(Long id, String authorName, String bookName, String genreName, Integer releaseYear);
 
     Book getBookById(Long bookId);
+
+    void addCommentToBook(Long bookId, String comment);
+
+    List<Comment> showComments(Long bookId);
 }
 

--- a/spring-library/src/main/java/ru/otus/homework/springlibrary/service/impl/BooksCrudServiceJpql.java
+++ b/spring-library/src/main/java/ru/otus/homework/springlibrary/service/impl/BooksCrudServiceJpql.java
@@ -1,0 +1,72 @@
+package ru.otus.homework.springlibrary.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import ru.otus.homework.springlibrary.domain.Author;
+import ru.otus.homework.springlibrary.domain.Book;
+import ru.otus.homework.springlibrary.domain.Comment;
+import ru.otus.homework.springlibrary.domain.Genre;
+import ru.otus.homework.springlibrary.repositories.BookRepository;
+import ru.otus.homework.springlibrary.service.BooksCrudService;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class BooksCrudServiceJpql implements BooksCrudService {
+
+    private final BookRepository bookRepository;
+
+    @Override
+    public Long getBooksCount() {
+        return bookRepository.count();
+    }
+
+    @Transactional
+    @Override
+    public Long addNewBook(String name, Integer releaseYear, String[] authors, String[] genre) {
+        List<Author> booksAuthors = Arrays.stream(authors).map(Author::new).collect(Collectors.toList());
+        List<Genre> booksGenres = Arrays.stream(genre).map(Genre::new).collect(Collectors.toList());
+        Book savedBook = bookRepository.save(new Book(name, releaseYear, booksAuthors, booksGenres));
+        return savedBook.getId();
+    }
+
+    @Transactional
+    @Override
+    public List<Book> getAllBooks() {
+        log.info("Выполнение запроса на получение всех книг");
+        return bookRepository.getAllBooks();
+    }
+
+    @Transactional
+    @Override
+    public void deleteBookById(Long bookId) {
+        bookRepository.deleteBookById(bookId);
+    }
+
+    @Transactional
+    @Override
+    public void updateBook(Long id, String authorName, String bookName, String genreName, Integer releaseYear) {
+        bookRepository.updateBookById(id, authorName, releaseYear, bookName, genreName);
+    }
+
+    @Override
+    public Book getBookById(Long bookId) {
+        return bookRepository.getBookById(bookId).orElseThrow(RuntimeException::new);
+    }
+
+    @Override
+    public void addCommentToBook(Long bookId, String comment) {
+        bookRepository.addCommentToBook(bookId, new Comment(comment));
+    }
+
+    @Override
+    public List<Comment> showComments(Long bookId) {
+        return bookRepository.getBookById(bookId).orElseThrow().getComments();
+    }
+}

--- a/spring-library/src/main/java/ru/otus/homework/springlibrary/shell/BooksCrudCommands.java
+++ b/spring-library/src/main/java/ru/otus/homework/springlibrary/shell/BooksCrudCommands.java
@@ -5,8 +5,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.shell.standard.ShellComponent;
 import org.springframework.shell.standard.ShellMethod;
 import org.springframework.shell.standard.ShellOption;
-import org.springframework.transaction.annotation.Transactional;
 import ru.otus.homework.springlibrary.domain.Book;
+import ru.otus.homework.springlibrary.domain.Comment;
 import ru.otus.homework.springlibrary.service.BooksCrudService;
 
 import java.util.List;
@@ -24,7 +24,6 @@ public class BooksCrudCommands {
     }
 
     @ShellMethod(value = "add a new Book", key = {"add a new Book", "insb"})
-    @Transactional
     public Long addNewBook(@ShellOption String name, @ShellOption Integer releaseYear, @ShellOption String[] authors, @ShellOption String[] genre) {
         return booksCrudService.addNewBook(name, releaseYear, authors, genre);
     }
@@ -34,13 +33,11 @@ public class BooksCrudCommands {
         return booksCrudService.getAllBooks();
     }
 
-    @Transactional
     @ShellMethod(value = "delete book by id", key = {"delete book by id", "did"})
     public void deleteBookById(@ShellOption Long bookId) {
         booksCrudService.deleteBookById(bookId);
     }
 
-    @Transactional
     @ShellMethod(value = "update book", key = {"updbook, upb"})
     public void updateBook(@ShellOption("--id") Long id,
                            @ShellOption("--ar") String authorName,
@@ -53,5 +50,16 @@ public class BooksCrudCommands {
     @ShellMethod(value = "get book by Id", key = {"get book by id", "gtb"})
     public Book getBookById(@ShellOption Long bookId) {
         return booksCrudService.getBookById(bookId);
+    }
+
+    @ShellMethod(value = "add comment to book", key = {"adcm"})
+    public void addCommentToBook(@ShellOption Long bookId, @ShellOption String comment) {
+        log.info("Добавление коммента к книге с id = {}", bookId);
+        booksCrudService.addCommentToBook(bookId, comment);
+    }
+
+    @ShellMethod(value = "show bookComments", key = "shb")
+    public List<Comment> showCommentOfBook(@ShellOption Long bookId) {
+        return booksCrudService.showComments(bookId);
     }
 }

--- a/spring-library/src/main/resources/application.yml
+++ b/spring-library/src/main/resources/application.yml
@@ -1,9 +1,14 @@
 spring:
   datasource:
-    url: jdbc:postgresql://localhost:5432/postgres
-    username: postgres
-    password: postgres
-    driver-class-name: org.postgresql.Driver
+    url: jdbc:h2:mem:testdb
     initialization-mode: always
-    schema: schema.sql
-    data: data.sql
+    driver-class-name: org.h2.Driver
+    continue-on-error: true
+
+  jpa:
+    generate-ddl: false
+    hibernate:
+      ddl-auto: none
+
+
+    show-sql: true

--- a/spring-library/src/main/resources/data.sql
+++ b/spring-library/src/main/resources/data.sql
@@ -1,5 +1,6 @@
-INSERT INTO books (id, name, release_year) values (-1, 'testing', 1984) ON CONFLICT ON CONSTRAINT books_pkey DO NOTHING;
-INSERT INTO authors (id, name, country) values (-1, 'testovich', 'mother_rus') ON CONFLICT ON CONSTRAINT authors_pkey DO NOTHING;
-INSERT INTO genres (id, name) values (-1, 'genrevovich') ON CONFLICT ON CONSTRAINT genres_pkey DO NOTHING;
-INSERT INTO authors_books (author_id, book_id) values (-1, -1) ON CONFLICT ON CONSTRAINT authors_books_pkey DO NOTHING;
-INSERT INTO books_genres (book_id, genre_id) values (-1, -1) ON CONFLICT ON CONSTRAINT books_genres_pkey DO NOTHING;
+INSERT INTO books (id, name, release_year) values (-1, 'testing', 1984);
+INSERT INTO authors (id, name, country) values (-1, 'testovich', 'mother_rus');
+INSERT INTO genres (id, name) values (-1, 'genrevovich');
+INSERT INTO authors_books (author_id, book_id) values (-1, -1);
+INSERT INTO books_genres (book_id, genre_id) values (-1, -1);
+INSERT INTO comments (id, book_id, comment) values (-1, -1, 'норм книга');

--- a/spring-library/src/main/resources/schema.sql
+++ b/spring-library/src/main/resources/schema.sql
@@ -1,20 +1,25 @@
-CREATE TABLE IF NOT EXISTS books (
-    id SERIAL NOT NULL PRIMARY KEY,
-    name VARCHAR(255),
-    release_year INTEGER
-);
-
+DROP TABLE IF EXISTS authors;
 CREATE TABLE IF NOT EXISTS authors (
     id SERIAL NOT NULL PRIMARY KEY,
     name VARCHAR(255) UNIQUE,
     country VARCHAR(255)
 );
 
+DROP TABLE IF EXISTS books;
+CREATE TABLE IF NOT EXISTS books (
+    id SERIAL NOT NULL PRIMARY KEY,
+    name VARCHAR(255),
+    release_year INTEGER
+);
+
+
+DROP TABLE IF EXISTS genres;
 CREATE TABLE IF NOT EXISTS genres (
     id SERIAL NOT NULL PRIMARY KEY,
     name VARCHAR(255) UNIQUE
 );
 
+DROP TABLE IF EXISTS books_genres;
 CREATE TABLE IF NOT EXISTS books_genres (
     book_id BIGINT,
     genre_id BIGINT,
@@ -23,12 +28,20 @@ CREATE TABLE IF NOT EXISTS books_genres (
     PRIMARY KEY(book_id, genre_id)
 );
 
+DROP TABLE IF EXISTS authors_books;
 CREATE TABLE IF NOT EXISTS authors_books (
     author_id BIGINT,
     book_id BIGINT,
     FOREIGN KEY(author_id) REFERENCES authors(id) ON DELETE CASCADE,
     FOREIGN KEY(book_id) REFERENCES books(id) ON DELETE CASCADE,
     PRIMARY KEY(author_id, book_id)
+);
+
+DROP TABLE IF EXISTS comments;
+CREATE TABLE IF NOT EXISTS comments (
+    id SERIAL NOT NULL PRIMARY KEY,
+    book_id BIGINT,
+    comment VARCHAR(2048)
 );
 
 

--- a/spring-library/src/test/java/ru/otus/homework/springlibrary/repositories/impl/AuthorRepositoryImplTest.java
+++ b/spring-library/src/test/java/ru/otus/homework/springlibrary/repositories/impl/AuthorRepositoryImplTest.java
@@ -1,0 +1,58 @@
+package ru.otus.homework.springlibrary.repositories.impl;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import ru.otus.homework.springlibrary.domain.Author;
+import ru.otus.homework.springlibrary.repositories.AuthorRepository;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(AuthorRepositoryImpl.class)
+class AuthorRepositoryImplTest {
+
+    @Autowired
+    private AuthorRepository repository;
+
+    @Test
+    @DisplayName("Проверка методов count и getAll")
+    void shouldGetExpectedCountOfAuthors() {
+        assertThat(repository.count()).isEqualTo(repository.getAllAuthors().size());
+    }
+
+    @Test
+    @DisplayName("Проверка удаления автора из БД по его Id")
+    void shouldDeleteAuthorById() {
+        Author savedAuthor = repository.save(new Author("testovichN1", "Russia"));
+        assertThat(repository.count()).isEqualTo(3);
+        repository.deleteAuthorById(savedAuthor.getId());
+        assertThat(repository.count()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("Тест по получению автора по его Id")
+    void shouldReturnTheSameAuthorWhichHasBeenSavedBefore() {
+        Author savedAuthor = repository.save(new Author("secondAuthor", "Canada"));
+        assertThat(repository.getAuthorById(savedAuthor.getId())).get().isEqualTo(savedAuthor);
+    }
+
+    @Test
+    @DisplayName("Проверка обновления автора по его id ")
+    void updateAuthorById() {
+        Author thirdAuthor = repository.save(new Author("ThirdAuthor"));
+        Map<String, String> updatedFields = new HashMap<>();
+        updatedFields.put("name", "newAuthor");
+        updatedFields.put("country", "newCountry");
+        repository.updateAuthorById(thirdAuthor.getId(), updatedFields);
+        Author updatedAuthor = repository.getAuthorById(thirdAuthor.getId()).orElseThrow();
+        assertThat(updatedAuthor.getCountry()).isEqualTo("newCountry");
+        assertThat(updatedAuthor.getName()).isEqualTo("newAuthor");
+        assertThat(updatedAuthor.getId()).isEqualTo(thirdAuthor.getId());
+    }
+}

--- a/spring-library/src/test/java/ru/otus/homework/springlibrary/repositories/impl/BookRepositoryImplTest.java
+++ b/spring-library/src/test/java/ru/otus/homework/springlibrary/repositories/impl/BookRepositoryImplTest.java
@@ -1,0 +1,72 @@
+package ru.otus.homework.springlibrary.repositories.impl;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import ru.otus.homework.springlibrary.domain.Book;
+import ru.otus.homework.springlibrary.domain.Comment;
+import ru.otus.homework.springlibrary.repositories.BookRepository;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(BookRepositoryImpl.class)
+class BookRepositoryImplTest {
+
+    @Autowired
+    private BookRepository bookRepository;
+
+    @DisplayName("Проверка метода count")
+    @Test
+    void shouldReturnExpectedCountOfBooks() {
+        assertThat(bookRepository.count()).isEqualTo(bookRepository.getAllBooks().size());
+    }
+
+
+    @Test
+    @DisplayName("Проверка метода getAll со всеми данными")
+    void shouldReturnAllBooksWithAllInfo() {
+        List<Book> allBooks = bookRepository.getAllBooks();
+        allBooks.forEach(book -> {
+            assertThat(book.getAuthors().size() > 0).isTrue();
+            assertThat(book.getGenres().size() > 0).isTrue();
+        });
+    }
+
+    @Test
+    @DisplayName("Проверка обновления книги по id")
+    void updateBookById() {
+        Book springBook = bookRepository.save(new Book("SpringBook", 123, null, null));
+
+        bookRepository.updateBookById(springBook.getId(), "Таска", 2020, "Jpql", "horror");
+
+        Book updatedBook = bookRepository.getBookById(springBook.getId()).orElseThrow();
+
+        assertThat(updatedBook.getAuthors().size() > 0).isTrue();
+        assertThat(updatedBook.getGenres().size() > 0).isTrue();
+        assertThat(updatedBook.getName()).isEqualTo("Jpql");
+        assertThat(updatedBook.getReleaseYear()).isEqualTo(2020);
+    }
+
+    @Test
+    @DisplayName("Проверка удаления книги по Id")
+    void shouldDeleteBookById() {
+        Book springBook = bookRepository.save(new Book("OtherTestBook", 1234, null, null));
+        Long countAfterAdd = bookRepository.count();
+        bookRepository.deleteBookById(springBook.getId());
+        assertThat(bookRepository.count()).isEqualTo(countAfterAdd - 1);
+    }
+
+    @Test
+    @DisplayName("Проверка добавления комментария к книге")
+    void shouldAddCommentToBook() {
+        Book springBook = bookRepository.save(new Book("SpringBook", 123, null, null));
+        bookRepository.addCommentToBook(springBook.getId(), new Comment("Неплохая книга, ДА!"));
+        Book bookWithComment = bookRepository.getBookById(springBook.getId()).orElseThrow();
+        assertThat(bookWithComment.getComments().get(0).getComment()).isEqualTo("Неплохая книга, ДА!");
+    }
+}

--- a/spring-library/src/test/java/ru/otus/homework/springlibrary/repositories/impl/GenreRepositoryImplTest.java
+++ b/spring-library/src/test/java/ru/otus/homework/springlibrary/repositories/impl/GenreRepositoryImplTest.java
@@ -1,0 +1,56 @@
+package ru.otus.homework.springlibrary.repositories.impl;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import ru.otus.homework.springlibrary.domain.Genre;
+import ru.otus.homework.springlibrary.repositories.GenreRepository;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@Import(GenreRepositoryImpl.class)
+class GenreRepositoryImplTest {
+
+    @Autowired
+    private GenreRepository genreRepository;
+
+    @Test
+    @DisplayName("Проверка методов count и getAll")
+    void shouldReturnTheSameLongThatAllMethodSize() {
+        assertThat(genreRepository.count()).isEqualTo(genreRepository.getAllGenres().size());
+    }
+
+    @Test
+    @DisplayName("Проверка удаления жанра")
+    void shouldDeleteGenreById() {
+        Genre genre = genreRepository.save(new Genre("Жанрович"));
+        Long countAfterAdd = genreRepository.count();
+        genreRepository.deleteGenreById(genre.getId());
+        assertThat(genreRepository.count()).isEqualTo(countAfterAdd - 1);
+    }
+
+    @Test
+    @DisplayName("Проверка метода получения жанра по id")
+    void shouldReturnGenreWithDefineId() {
+        Genre expectedGenre = genreRepository.save(new Genre("Получаемый жанр"));
+        Genre actualGenre = genreRepository.getGenreById(expectedGenre.getId()).orElseThrow();
+        assertThat(actualGenre).isEqualTo(expectedGenre);
+    }
+
+    @Test
+    @DisplayName("Проверка метода обновления сущности \"Genre\"")
+    void shouldUpdateGenreById() {
+        Genre expectedGenre = genreRepository.save(new Genre("Жанр до обновления"));
+        Map<String, String> updatedFields = new HashMap<>();
+        updatedFields.put("name", "Жанр после обновления");
+        genreRepository.updateGenreById(expectedGenre.getId(), updatedFields);
+        Genre afterUpdate = genreRepository.getGenreById(expectedGenre.getId()).orElseThrow();
+        assertThat(afterUpdate.getName()).isEqualTo("Жанр после обновления");
+    }
+}

--- a/spring-library/src/test/java/ru/otus/homework/springlibrary/shell/BooksCrudCommandsTest.java
+++ b/spring-library/src/test/java/ru/otus/homework/springlibrary/shell/BooksCrudCommandsTest.java
@@ -4,10 +4,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import ru.otus.homework.springlibrary.dao.BookDao;
-import ru.otus.homework.springlibrary.dao.jdbc.AuthorDaoJdbc;
-import ru.otus.homework.springlibrary.dao.jdbc.GenreDaoJdbc;
+import org.springframework.transaction.annotation.Transactional;
 import ru.otus.homework.springlibrary.domain.Book;
+import ru.otus.homework.springlibrary.repositories.BookRepository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -19,12 +18,7 @@ class BooksCrudCommandsTest {
     @Autowired
     private BooksCrudCommands booksCrudCommands;
     @Autowired
-    private GenreDaoJdbc genreDaoJdbc;
-    @Autowired
-    private AuthorDaoJdbc authorDaoJdbc;
-    @Autowired
-    private BookDao bookDao;
-
+    private BookRepository bookRepository;
 
     @Test
     @DisplayName("Проверка методов getAll() и Count()")
@@ -36,16 +30,14 @@ class BooksCrudCommandsTest {
     @DisplayName("Добавление информации о новой книги в основные(books, genres, authors) и связующие таблицы")
     void shouldAddNewRecordToBooksAuthorsGenresAndLinkedTables() {
         Long addedBookId = booksCrudCommands.addNewBook("newTestingBook", 1984, new String[]{"Оруэлл"}, new String[]{"жизнь"});
-        assertThat(genreDaoJdbc.getGenresByBookId(addedBookId).size()).isEqualTo(1);
-        assertThat(authorDaoJdbc.getAuthorsByBookId(addedBookId).size()).isEqualTo(1);
-        assertThat(authorDaoJdbc.getAuthorsByBookId(addedBookId).size()).isEqualTo(1);
-        assertThat(bookDao.getBookById(addedBookId).getName()).isEqualTo("newTestingBook");
+        assertThat(bookRepository.getBookById(addedBookId).orElseThrow().getName()).isEqualTo("newTestingBook");
         booksCrudCommands.deleteBookById(addedBookId);
 
     }
 
     @Test
     @DisplayName("Проверка обновление книги")
+    @Transactional
     void shouldUpdateBook() {
 
         Book beforeUpdatedBook = booksCrudCommands.getBookById(INITIAL_BOOK_ID);
@@ -54,12 +46,10 @@ class BooksCrudCommandsTest {
 
         booksCrudCommands.updateBook(INITIAL_BOOK_ID, "новый автор", "новое имя", "новый жанр", 1920);
 
-        assertThat(authorDaoJdbc.getAuthorsByBookId(INITIAL_BOOK_ID).size()).isEqualTo(2);
         assertThat(booksCrudCommands.getBookById(INITIAL_BOOK_ID).getAuthors().stream().anyMatch(author -> author.getName().equals("новый автор"))).isTrue();
         assertThat(booksCrudCommands.getBookById(INITIAL_BOOK_ID).getGenres().stream().anyMatch(genre -> genre.getName().equals("новый жанр"))).isTrue();
-        assertThat(bookDao.getBookById(INITIAL_BOOK_ID).getName()).isEqualTo("новое имя");
-        assertThat(bookDao.getBookById(INITIAL_BOOK_ID).getReleaseYear()).isEqualTo(1920);
-
-        booksCrudCommands.updateBook(INITIAL_BOOK_ID, beforeUpdatedBook.getAuthors().get(0).getName(), beforeUpdatedBook.getName(), beforeUpdatedBook.getGenres().get(0).getName(), beforeUpdatedBook.getReleaseYear());
+        assertThat(booksCrudCommands.getBookById(INITIAL_BOOK_ID).getReleaseYear()).isEqualTo(1920);
+        assertThat(booksCrudCommands.getBookById(INITIAL_BOOK_ID).getName()).isEqualTo("новое имя");
     }
+
 }

--- a/spring-library/src/test/resources/application.yml
+++ b/spring-library/src/test/resources/application.yml
@@ -1,12 +1,18 @@
 spring:
   datasource:
-    url: jdbc:postgresql://localhost:5432/test
-    username: postgres
-    password: postgres
-    driver-class-name: org.postgresql.Driver
+    url: jdbc:h2:mem:testdb
     initialization-mode: always
-    schema: schema.sql
-    data: data.sql
+    driver-class-name: org.h2.Driver
+    continue-on-error: true
+
+  jpa:
+    generate-ddl: false
+    hibernate:
+      ddl-auto: none
+
+
+    show-sql: true
+
   shell:
     interactive:
       enabled: false

--- a/spring-library/src/test/resources/data.sql
+++ b/spring-library/src/test/resources/data.sql
@@ -1,11 +1,13 @@
-INSERT INTO books (id, name, release_year) values (-1, 'testing', 1984) ON CONFLICT ON CONSTRAINT books_pkey DO NOTHING;
-INSERT INTO authors (id, name, country) values (-1, 'testovich', 'mother_rus') ON CONFLICT ON CONSTRAINT authors_pkey DO NOTHING;
-INSERT INTO genres (id, name) values (-1, 'genrevovich') ON CONFLICT ON CONSTRAINT genres_pkey DO NOTHING;
-INSERT INTO authors_books (author_id, book_id) values (-1, -1) ON CONFLICT ON CONSTRAINT authors_books_pkey DO NOTHING;
-INSERT INTO books_genres (book_id, genre_id) values (-1, -1) ON CONFLICT ON CONSTRAINT books_genres_pkey DO NOTHING;
+INSERT INTO books (id, name, release_year) values (-1, 'testing', 1984);
+INSERT INTO authors (id, name, country) values (-1, 'testovich', 'mother_rus');
+INSERT INTO genres (id, name) values (-1, 'genrevovich');
+INSERT INTO authors_books (author_id, book_id) values (-1, -1);
+INSERT INTO books_genres (book_id, genre_id) values (-1, -1) ;
 
-INSERT INTO books (id, name, release_year) values (-2, 'second', 1999) ON CONFLICT ON CONSTRAINT books_pkey DO NOTHING;
-INSERT INTO authors (id, name, country) values (-2, 'testovich2', 'mother_rus2') ON CONFLICT ON CONSTRAINT authors_pkey DO NOTHING;
-INSERT INTO genres (id, name) values (-2, 'comedy') ON CONFLICT ON CONSTRAINT genres_pkey DO NOTHING;
-INSERT INTO authors_books (author_id, book_id) values (-2, -2) ON CONFLICT ON CONSTRAINT authors_books_pkey DO NOTHING;
-INSERT INTO books_genres (book_id, genre_id) values (-2, -2) ON CONFLICT ON CONSTRAINT books_genres_pkey DO NOTHING;
+INSERT INTO books (id, name, release_year) values (-2, 'second', 1999);
+INSERT INTO authors (id, name, country) values (-2, 'testovich2', 'mother_rus2');
+INSERT INTO genres (id, name) values (-2, 'comedy');
+INSERT INTO authors_books (author_id, book_id) values (-2, -2);
+INSERT INTO books_genres (book_id, genre_id) values (-2, -2);
+INSERT INTO comments (id, book_id, comment) values (-1, -1, 'норм книга');
+

--- a/spring-library/src/test/resources/schema.sql
+++ b/spring-library/src/test/resources/schema.sql
@@ -1,20 +1,25 @@
-CREATE TABLE IF NOT EXISTS books (
-    id SERIAL NOT NULL PRIMARY KEY,
-    name VARCHAR(255),
-    release_year INTEGER
-);
-
+DROP TABLE IF EXISTS authors;
 CREATE TABLE IF NOT EXISTS authors (
     id SERIAL NOT NULL PRIMARY KEY,
     name VARCHAR(255) UNIQUE,
     country VARCHAR(255)
 );
 
+DROP TABLE IF EXISTS books;
+CREATE TABLE IF NOT EXISTS books (
+    id SERIAL NOT NULL PRIMARY KEY,
+    name VARCHAR(255),
+    release_year INTEGER
+);
+
+
+DROP TABLE IF EXISTS genres;
 CREATE TABLE IF NOT EXISTS genres (
     id SERIAL NOT NULL PRIMARY KEY,
     name VARCHAR(255) UNIQUE
 );
 
+DROP TABLE IF EXISTS books_genres;
 CREATE TABLE IF NOT EXISTS books_genres (
     book_id BIGINT,
     genre_id BIGINT,
@@ -23,6 +28,7 @@ CREATE TABLE IF NOT EXISTS books_genres (
     PRIMARY KEY(book_id, genre_id)
 );
 
+DROP TABLE IF EXISTS authors_books;
 CREATE TABLE IF NOT EXISTS authors_books (
     author_id BIGINT,
     book_id BIGINT,
@@ -30,6 +36,14 @@ CREATE TABLE IF NOT EXISTS authors_books (
     FOREIGN KEY(book_id) REFERENCES books(id) ON DELETE CASCADE,
     PRIMARY KEY(author_id, book_id)
 );
+
+DROP TABLE IF EXISTS comments;
+CREATE TABLE IF NOT EXISTS comments (
+    id SERIAL NOT NULL PRIMARY KEY,
+    book_id BIGINT,
+    comment VARCHAR(2048)
+);
+
 
 
 


### PR DESCRIPTION
Цель: Цель: полноценно работать с JPA + Hibernate для подключения к реляционным БД посредством ORM-фреймворка Результат: Высокоуровневое приложение с JPA-маппингом сущностей
Домашнее задание выполняется переписыванием предыдущего на JPA.

Требования:
1. Использовать JPA, Hibernate только в качестве JPA-провайдера.
2. Добавить комментарии к книгам, и высокоуровневые сервисы, оставляющие комментарии к книгам.
3. Покрыть репозитории тестами, используя H2 базу данных и соответствующий H2 Hibernate-диалект для тестов.
4. Не забудьте отключить DDL через Hibernate